### PR TITLE
Remove deprecated command warn

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -39,7 +39,6 @@
   command: "touch {{ mysql_slow_query_log_file }}"
   args:
     creates: "{{ mysql_slow_query_log_file }}"
-    warn: false
   when: mysql_slow_query_log_enabled
 
 - name: Create datadir if it does not exist
@@ -64,7 +63,6 @@
   command: "touch {{ mysql_log_error }}"
   args:
     creates: "{{ mysql_log_error }}"
-    warn: false
   when:
     - mysql_log == ""
     - mysql_log_error != ""


### PR DESCRIPTION
https://github.com/ansible-lockdown/RHEL7-CIS/issues/315 base on this link, in Ansible 2.14 the command arg module was removed and therefore no longer valid.

I've just removed these calls and verified in the infrastructure repository, that using this branch version, I'm able to continue creating an AMI that uses this role.